### PR TITLE
Feature/v0.1.3 patch

### DIFF
--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -105,9 +105,6 @@ module Fluent
     def generate_metric(key, tokens, time, value)
       name = @name_processor.nil? ? key :
                @name_processor.map{ |p| p.call(:out_key => key, :tokens => tokens) }.join('.')
-      unless @container_id.nil?
-        name = "name.#{container_id}"
-      end
 
       metric = {
         'value' => value,

--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -160,13 +160,18 @@ module Fluent
           end
         end
       end
-
       send(metrics) unless metrics.empty?
       metrics.clear
     end
 
     def send(metrics)
       log.debug("out_mackerel: #{metrics}")
+
+      if metrics.collect{|m| m['time']}.any?{|w| w == 0}
+        log.warn('out_mackerel: time in metrics is zero')
+        return
+      end
+
       begin
         if @hostid
           @mackerel.post_metrics(metrics)

--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -124,10 +124,6 @@ module Fluent
         tags[tag] = true
         tokens = tag.split('.')
 
-        if record.has_key?('container_id')
-          container_id = record["container_id"]
-        end
-
         if @out_keys
           out_keys = @out_keys.select{|key| record.has_key?(key)}
         else # @out_key_pattern
@@ -140,9 +136,9 @@ module Fluent
           processed[tag + "." + key] = true
         end
 
-        if container_id
+        if record.has_key?('container_id')
           metrics.each do |m|
-            m['name'] = m['name'].gsub('#', container_id)
+            m['name'] = m['name'].gsub('#', record["container_id"])
           end
         end
       end


### PR DESCRIPTION
# 変更内容
- ログにcontainer_idが含まれた場合、Mackerelの#を置き換えて送信する
- 意図しないログを受け取ってtimeが0になってしまう場合、失敗せずにwarnのログを出力する